### PR TITLE
Add ccmod.json

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -1,0 +1,10 @@
+{
+  "id": "readable-saves",
+  "version": "1.0.1",
+  "title": "Readable saves",
+  "description": "Unencrypts the save file and adds an additional save format suitable for editing by hand",
+  "repository": "https://github.com/dmitmel/crosscode-readable-saves",
+  "tags": ["dev"],
+  "authors": "dmitmel",
+  "postload": "dist/postload.js"
+}


### PR DESCRIPTION
CCModDB now requires `ccmod.json` to be present.
Please create a new release or update the release `.ccmod` after merging.
